### PR TITLE
Add billing_address and shipping_address array parameters to the crea…

### DIFF
--- a/src/ServiceDescription/TradeGecko-v1.php
+++ b/src/ServiceDescription/TradeGecko-v1.php
@@ -3160,6 +3160,11 @@ return [
                     'type' => 'string',
                     'required' => false,
                 ],
+                'billing_address' => [
+                    'location' => 'json',
+                    'type' => 'array',
+                    'required' => false,
+                ],
                 'billing_address_id' => [
                     'location' => 'json',
                     'type' => 'integer',
@@ -3174,6 +3179,11 @@ return [
                     'location' => 'json',
                     'type' => 'integer',
                     'required' => false,
+                ],
+                'shipping_address' => [
+                    'location' => 'json',
+                    'type' => 'array',
+                    'required' => false
                 ],
                 'shipping_address_id' => [
                     'location' => 'json',


### PR DESCRIPTION
…teOrder description

- Add billing_address and shipping_address array parameters to the createOrder description

At the moment you can only pass a billing or shipping ID to the API using this integration as it's missing the 'shipping_address' and 'billing_address' array parameters. Please see example number two here in the TradeGecko API docs, where you can create an order with a shipping or billing address with only one request, rather than having to create the addresses first. 

Not sure why this is, but it would make sense to implement everything that's within the API docs.

https://developer.tradegecko.com/docs.html#2-order-with-existing-customer-but-new-address