### PR TITLE
Add support for idempotency token header

### DIFF
--- a/src/TradeGeckoClient.php
+++ b/src/TradeGeckoClient.php
@@ -347,6 +347,12 @@ class TradeGeckoClient
         }
 
         $args = $args[0] ?? [];
+        $idempotencyToken;
+        if (isset($args['idempotency_token'])) {
+            $idempotencyToken = $args['idempotency_token'];
+            unset($args['idempotency_token']);
+        }
+
         $args = array_merge($args, [
             '@http' => [
                 'headers' => [
@@ -354,6 +360,9 @@ class TradeGeckoClient
                 ]
             ]
         ]);
+        if (isset($idempotencyToken)) {
+            $args['@http']['headers']['Idempotency-Key'] = $idempotencyToken;
+        }
 
         $command = $this->guzzleClient->getCommand(ucfirst($method), $args);
         $result  = $this->guzzleClient->execute($command);

--- a/test/TradeGeckoClientTest.php
+++ b/test/TradeGeckoClientTest.php
@@ -111,4 +111,42 @@ class TradeGeckoClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(['id' => 123], $payload);
     }
+
+    public function testMagicMethodWithIdempotencyToken()
+    {
+        $serviceClient = $this->prophesize(GuzzleClient::class);
+        $client = new TradeGeckoClient('access_token_123', $serviceClient->reveal());
+
+        $expectedArgs = [
+            '@http'  => [
+                'headers' => [
+                    'Authorization' => 'Bearer access_token_123',
+                    'Idempotency-Key' => 'uniqueToken'
+                ]
+            ]
+        ];
+
+        $command = $this->prophesize(CommandInterface::class);
+        $command->getName()->shouldBeCalled()->willReturn('UpdateOrder');
+
+        $result = $this->prophesize(ToArrayInterface::class);
+        $result->toArray()->shouldBeCalled()->willReturn([
+            'order' => ['id' => 456],
+        ]);
+
+        $serviceClient->getCommand('UpdateOrder', $expectedArgs)->shouldBeCalled()->willReturn($command->reveal());
+        $serviceClient->execute($command)->shouldBeCalled()->willReturn($result->reveal());
+
+        $description = $this->prophesize(DescriptionInterface::class);
+        $serviceClient->getDescription()->shouldBeCalled()->willReturn($description->reveal());
+
+        $operation = $this->prophesize(Operation::class);
+        $description->getOperation('UpdateOrder')->shouldBeCalled()->willReturn($operation->reveal());
+
+        $operation->getData('root_key')->shouldBeCalled()->willReturn('order');
+
+        $payload = $client->updateOrder(['idempotency_token' => 'uniqueToken']);
+
+        $this->assertEquals(['id' => 456], $payload);
+    }
 }


### PR DESCRIPTION
Just added support for the Tradegecko Idempotency Token as specified in the doc here : https://developer.tradegecko.com/docs.html#idempotency-tokens

Context: When under important API loads, Tradegecko starts to reply with 5xx HTTP code to requests, but it turns out that the requests are handled anyway in Tradegecko.
I realized that after doing lot of order lines updates and saw that many of my requests created double (or more) entries in the orders.
This is due to the fact that the library retry automatically when a 5xx response code is received (see `retryDecider` function in `TradeGeckoClient`).

The solution is to add an unique idempotency token in the header of the request, so even if Tradegecko receives more than once the same request, it's able to execute it only once using that token.

I realize that it might not be the best way to add support for that, but I wasn't able to make it work properly only by editing `ServiceDescription/TradeGecko-v1.php`.
I'm open to any suggestion to make it cleaner :)